### PR TITLE
Explicitly declare module name and move base mod class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,8 @@ minecraft {
                     '--all',
                     '--output', file('src/data/resources/'),
                     '--existing', file('src/main/resources/'),
-                    '--existing', configurations.ilikewood.asPath
+                    '--existing', configurations.ilikewood.asPath,
+                    '--existing-mod', 'biomesoplenty'
 
             mods {
                 ilikewoodxbiomesoplenty {
@@ -142,7 +143,8 @@ jar {
                 "Implementation-Title"    : "ilikewoodxbiomesoplenty",
                 "Implementation-Version"  : "${project.version}",
                 "Implementation-Vendor"   : "yamahari",
-                "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
+                "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
+                "Automatic-Module-Name": "ilikewoodxbiomesoplenty"
         ])
     }
 

--- a/src/main/java/yamahari/ilikewood/plugin/biomesoplenty/ILikeWoodXBiomesOPlenty.java
+++ b/src/main/java/yamahari/ilikewood/plugin/biomesoplenty/ILikeWoodXBiomesOPlenty.java
@@ -1,4 +1,4 @@
-package yamahari.ilikewood.plugin;
+package yamahari.ilikewood.plugin.biomesoplenty;
 
 import net.minecraftforge.fml.common.Mod;
 import yamahari.ilikewood.plugin.biomesoplenty.util.Constants;


### PR DESCRIPTION
- Explicitly declare module name
- Moved base mod class one package deeper to not conflict with byg plugin due to exporting same package of yamahari.ilikewood.plugin to modules